### PR TITLE
feat: implement payment service with Kafka consumer/producer and JPA …

### DIFF
--- a/docs/learning-notes.md
+++ b/docs/learning-notes.md
@@ -1,0 +1,127 @@
+# Learning Notes: Event-Driven Delivery ETA System
+
+## Kafka Fundamentals
+
+### Topics & Partitions
+
+| Concept | Definition | Example |
+|---------|------------|---------|
+| **Topic** | Named channel for messages | `raw.payment-events` |
+| **Partition** | Subdivision for parallelism | 3 partitions per topic |
+| **Partition Key** | Determines which partition | `orderId` → same order, same partition |
+
+```
+Topic: raw.inventory-events (3 partitions)
+┌──────────┐  ┌──────────┐  ┌──────────┐
+│Partition0│  │Partition1│  │Partition2│
+│ Order-A  │  │ Order-B  │  │ Order-C  │
+│ Order-D  │  │ Order-E  │  │ Order-F  │
+└──────────┘  └──────────┘  └──────────┘
+```
+
+### Consumer Groups
+
+**Same group** = messages split (work sharing)
+**Different groups** = messages duplicated (each group sees all)
+
+```
+                    Topic
+                      │
+         ┌────────────┼────────────┐
+         ▼                         ▼
+   payment-service-group     analytics-group
+   (splits work)             (gets same messages)
+```
+
+### Partitions vs Instances
+
+| Scenario | Result |
+|----------|--------|
+| 3 partitions, 3 instances | Perfect — each gets 1 |
+| 3 partitions, 2 instances | One instance gets 2 partitions |
+| 2 partitions, 3 instances | One instance sits IDLE |
+
+**Rule**: Max parallelism = number of partitions
+
+---
+
+## Java/Spring Concepts
+
+### Package Structure
+
+```
+src/main/java/com/delivery/payment/listener/
+                 ↑      ↑       ↑
+              domain  module  feature
+```
+
+Package in code MUST match folder path after `src/main/java/`.
+
+### @KafkaListener
+
+```java
+@KafkaListener(topics = Topics.INVENTORY_EVENTS, groupId = "${spring.kafka.consumer.group-id}")
+public void handleEvent(String message) { ... }
+```
+
+- `topics` — which Kafka topic to subscribe to
+- `groupId` — consumer group (from application.yml via `${}`)
+- Spring auto-commits offset after method completes successfully
+
+### Property Placeholders
+
+`${spring.kafka.consumer.group-id}` reads from `application.yml`:
+```yaml
+spring:
+  kafka:
+    consumer:
+      group-id: payment-service-group  # ← injected
+```
+
+---
+
+## System Flow
+
+```
+order.created → inventory.reserved → payment.authorized → delivery.assigned → eta.updated
+```
+
+### Payment Service
+
+| Listens To | Publishes |
+|------------|-----------|
+| `raw.inventory-events` | `raw.payment-events` |
+| `inventory.reserved` | `payment.authorized` or `payment.failed` |
+
+---
+
+## Database Patterns
+
+### Database Per Service
+
+Each service owns its tables — no cross-service JOINs.
+Communication happens via Kafka events, not database queries.
+
+| Service | Storage |
+|---------|---------|
+| order-service | Postgres (orders) |
+| payment-service | Postgres (payments) |
+| delivery-service | Cassandra (history) + Redis (current) |
+
+### Idempotency
+
+Kafka delivers at-least-once → duplicates possible.
+Solution: Store `idempotency_key` (event ID) with unique constraint.
+
+---
+
+## Quick Reference
+
+| Term | One-liner |
+|------|-----------|
+| Partition | Unit of parallelism in Kafka |
+| Consumer Group | Consumers that share partition work |
+| Offset | Bookmark — position in partition |
+| ACID | Atomicity, Consistency, Isolation, Durability |
+| At-least-once | Message may be delivered multiple times |
+| Idempotency | Same operation, same result (handles duplicates) |

--- a/services/payment-service/src/main/java/com/delivery/payment/config/JacksonConfig.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/config/JacksonConfig.java
@@ -1,0 +1,37 @@
+package com.delivery.payment.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Jackson configuration for JSON serialization.
+ * 
+ * CONCEPT: @Configuration + @Bean
+ * - @Configuration marks this class as a source of bean definitions
+ * - @Bean methods create objects that Spring manages
+ * - Other classes can then @Autowire/inject these beans
+ */
+@Configuration
+public class JacksonConfig {
+
+    /**
+     * Configure ObjectMapper with Java 8 time support.
+     * 
+     * Without this, Instant/LocalDateTime won't serialize properly.
+     */
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Support for java.time.Instant, LocalDateTime, etc.
+        mapper.registerModule(new JavaTimeModule());
+
+        // Write dates as ISO strings, not timestamps
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        return mapper;
+    }
+}

--- a/services/payment-service/src/main/java/com/delivery/payment/dto/InventoryEventPayload.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/dto/InventoryEventPayload.java
@@ -1,0 +1,55 @@
+package com.delivery.payment.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * Payload from inventory.reserved events.
+ * 
+ * CONCEPT: DTO (Data Transfer Object)
+ * - Simple class to hold data from incoming events
+ * - Maps to the "payload" field in EventEnvelope
+ */
+public class InventoryEventPayload {
+
+    private String orderId;
+    private BigDecimal amount;
+    private String currency;
+    private String customerId;
+
+    // Default constructor for Jackson
+    public InventoryEventPayload() {
+    }
+
+    // Getters and Setters
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(String customerId) {
+        this.customerId = customerId;
+    }
+}

--- a/services/payment-service/src/main/java/com/delivery/payment/dto/PaymentEventPayload.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/dto/PaymentEventPayload.java
@@ -1,0 +1,74 @@
+package com.delivery.payment.dto;
+
+import com.delivery.payment.entity.PaymentStatus;
+
+import java.math.BigDecimal;
+
+/**
+ * Payload for payment.authorized and payment.failed events.
+ * 
+ * This is what we publish to Kafka in the EventEnvelope.payload field.
+ */
+public class PaymentEventPayload {
+
+    private Long paymentId;
+    private String orderId;
+    private BigDecimal amount;
+    private String currency;
+    private PaymentStatus status;
+    private String failureReason;
+
+    // Default constructor
+    public PaymentEventPayload() {
+    }
+
+    // Builder-style static factory
+    public static PaymentEventPayload fromAuthorized(Long paymentId, String orderId,
+            BigDecimal amount, String currency) {
+        PaymentEventPayload payload = new PaymentEventPayload();
+        payload.paymentId = paymentId;
+        payload.orderId = orderId;
+        payload.amount = amount;
+        payload.currency = currency;
+        payload.status = PaymentStatus.AUTHORIZED;
+        return payload;
+    }
+
+    public static PaymentEventPayload fromFailed(Long paymentId, String orderId,
+            BigDecimal amount, String currency,
+            String reason) {
+        PaymentEventPayload payload = new PaymentEventPayload();
+        payload.paymentId = paymentId;
+        payload.orderId = orderId;
+        payload.amount = amount;
+        payload.currency = currency;
+        payload.status = PaymentStatus.FAILED;
+        payload.failureReason = reason;
+        return payload;
+    }
+
+    // Getters
+    public Long getPaymentId() {
+        return paymentId;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+}

--- a/services/payment-service/src/main/java/com/delivery/payment/entity/Payment.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/entity/Payment.java
@@ -1,0 +1,134 @@
+package com.delivery.payment.entity;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Payment entity - persisted to Postgres.
+ * 
+ * CONCEPT: JPA Entity
+ * - @Entity marks this class for database persistence
+ * - @Table specifies the table name
+ * - @Id marks the primary key
+ * - Hibernate auto-creates/updates table based on this class
+ * 
+ * CONCEPT: Idempotency Key
+ * - Kafka delivers at-least-once → duplicates possible
+ * - We store 'idempotencyKey' (usually eventId) with UNIQUE constraint
+ * - If we try to insert duplicate → database rejects it
+ * - This prevents processing same payment twice!
+ */
+@Entity
+@Table(name = "payments")
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * The order this payment is for.
+     */
+    @Column(nullable = false)
+    private String orderId;
+
+    /**
+     * Unique key to prevent duplicate processing.
+     * Usually the eventId from the Kafka message.
+     */
+    @Column(nullable = false, unique = true)
+    private String idempotencyKey;
+
+    /**
+     * Payment amount.
+     * Using BigDecimal for money - never use float/double for currency!
+     */
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal amount;
+
+    /**
+     * Currency code (e.g., USD, EUR).
+     */
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    /**
+     * Payment status: PENDING, AUTHORIZED, FAILED
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
+
+    /**
+     * When the payment was created.
+     */
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    /**
+     * When the payment was last updated.
+     */
+    private Instant updatedAt;
+
+    // Default constructor for JPA
+    public Payment() {
+    }
+
+    // Builder-style creation
+    public static Payment create(String orderId, String idempotencyKey,
+            BigDecimal amount, String currency) {
+        Payment payment = new Payment();
+        payment.orderId = orderId;
+        payment.idempotencyKey = idempotencyKey;
+        payment.amount = amount;
+        payment.currency = currency;
+        payment.status = PaymentStatus.PENDING;
+        payment.createdAt = Instant.now();
+        return payment;
+    }
+
+    // Status transitions
+    public void authorize() {
+        this.status = PaymentStatus.AUTHORIZED;
+        this.updatedAt = Instant.now();
+    }
+
+    public void fail() {
+        this.status = PaymentStatus.FAILED;
+        this.updatedAt = Instant.now();
+    }
+
+    // Getters
+    public Long getId() {
+        return id;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/services/payment-service/src/main/java/com/delivery/payment/entity/PaymentStatus.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/entity/PaymentStatus.java
@@ -1,0 +1,14 @@
+package com.delivery.payment.entity;
+
+/**
+ * Payment status enum.
+ * 
+ * CONCEPT: State Machine
+ * Payments transition: PENDING → AUTHORIZED or PENDING → FAILED
+ * Once AUTHORIZED or FAILED, the payment is final.
+ */
+public enum PaymentStatus {
+    PENDING, // Payment created, not yet processed
+    AUTHORIZED, // Payment successful
+    FAILED // Payment failed (insufficient funds, card declined, etc.)
+}

--- a/services/payment-service/src/main/java/com/delivery/payment/listener/PaymentEventListener.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/listener/PaymentEventListener.java
@@ -1,0 +1,111 @@
+package com.delivery.payment.listener;
+
+import com.delivery.common.event.EventTypes;
+import com.delivery.common.event.Topics;
+import com.delivery.payment.service.PaymentProcessor;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+/**
+ * Kafka consumer that listens for inventory events.
+ * 
+ * CONCEPT: @KafkaListener
+ * - Spring creates a background thread that polls Kafka
+ * - Each message triggers this method
+ * - groupId identifies this consumer group (for offset tracking)
+ * - Multiple instances with same groupId share partitions
+ */
+@Component
+public class PaymentEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentEventListener.class);
+
+    private final ObjectMapper objectMapper;
+    private final PaymentProcessor paymentProcessor;
+
+    public PaymentEventListener(ObjectMapper objectMapper, PaymentProcessor paymentProcessor) {
+        this.objectMapper = objectMapper;
+        this.paymentProcessor = paymentProcessor;
+    }
+
+    /**
+     * Listens to inventory events topic.
+     * 
+     * CONCEPT: Consumer Flow
+     * 1. Kafka delivers message to this method
+     * 2. We deserialize and check event type
+     * 3. Only process "inventory.reserved" (ignore others)
+     * 4. If method completes without exception → offset committed
+     * 5. If exception thrown → message will be redelivered (at-least-once)
+     */
+    @KafkaListener(topics = Topics.INVENTORY_EVENTS, groupId = "${spring.kafka.consumer.group-id}")
+    public void handleInventoryEvent(String message) {
+        log.info("Received inventory event: {}", message);
+
+        try {
+            // Parse the JSON event envelope
+            JsonNode eventNode = objectMapper.readTree(message);
+            String eventType = eventNode.get("eventType").asText();
+            String orderId = eventNode.get("orderId").asText();
+            String eventId = eventNode.get("eventId").asText();
+            String correlationId = eventNode.has("correlationId")
+                    ? eventNode.get("correlationId").asText()
+                    : eventId;
+
+            log.info("Processing event: type={}, orderId={}, eventId={}",
+                    eventType, orderId, eventId);
+
+            // Route based on event type
+            switch (eventType) {
+                case EventTypes.INVENTORY_RESERVED:
+                    handleInventoryReserved(eventNode, eventId, correlationId);
+                    break;
+                case EventTypes.INVENTORY_REJECTED:
+                    handleInventoryRejected(eventNode);
+                    break;
+                default:
+                    log.warn("Unknown event type: {}", eventType);
+            }
+
+        } catch (Exception e) {
+            // CONCEPT: Error Handling
+            // In production, we'd send to DLQ after retries
+            // For now, log and rethrow to trigger retry
+            log.error("Failed to process event: {}", e.getMessage(), e);
+            throw new RuntimeException("Event processing failed", e);
+        }
+    }
+
+    private void handleInventoryReserved(JsonNode eventNode, String eventId,
+            String correlationId) {
+        String orderId = eventNode.get("orderId").asText();
+        JsonNode payload = eventNode.get("payload");
+
+        // Extract payment details from payload
+        BigDecimal amount = payload.has("amount")
+                ? new BigDecimal(payload.get("amount").asText())
+                : new BigDecimal("0.00");
+        String currency = payload.has("currency")
+                ? payload.get("currency").asText()
+                : "USD";
+
+        log.info("Processing payment for order: {}, amount: {} {}", orderId, amount, currency);
+
+        // Process payment using eventId as idempotency key
+        paymentProcessor.processPayment(orderId, eventId, amount, currency, correlationId);
+    }
+
+    private void handleInventoryRejected(JsonNode eventNode) {
+        String orderId = eventNode.get("orderId").asText();
+        log.info("Inventory rejected for order: {}, skipping payment", orderId);
+
+        // No payment needed - inventory wasn't available
+        // Could optionally publish payment.skipped event
+    }
+}

--- a/services/payment-service/src/main/java/com/delivery/payment/publisher/PaymentEventPublisher.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/publisher/PaymentEventPublisher.java
@@ -1,0 +1,93 @@
+package com.delivery.payment.publisher;
+
+import com.delivery.common.event.EventEnvelope;
+import com.delivery.common.event.EventTypes;
+import com.delivery.common.event.Topics;
+import com.delivery.payment.dto.PaymentEventPayload;
+import com.delivery.payment.entity.Payment;
+import com.delivery.payment.entity.PaymentStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes payment events to Kafka.
+ * 
+ * CONCEPT: KafkaTemplate
+ * - Spring's helper for publishing messages to Kafka
+ * - send(topic, key, value) publishes a message
+ * - Key is used for partitioning (same key → same partition)
+ */
+@Component
+public class PaymentEventPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentEventPublisher.class);
+    private static final String PRODUCER_NAME = "payment-service";
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public PaymentEventPublisher(KafkaTemplate<String, String> kafkaTemplate,
+            ObjectMapper objectMapper) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Publish payment event based on payment status.
+     */
+    public void publishPaymentEvent(Payment payment, String correlationId) {
+        String eventType = payment.getStatus() == PaymentStatus.AUTHORIZED
+                ? EventTypes.PAYMENT_AUTHORIZED
+                : EventTypes.PAYMENT_FAILED;
+
+        PaymentEventPayload payload = payment.getStatus() == PaymentStatus.AUTHORIZED
+                ? PaymentEventPayload.fromAuthorized(
+                        payment.getId(),
+                        payment.getOrderId(),
+                        payment.getAmount(),
+                        payment.getCurrency())
+                : PaymentEventPayload.fromFailed(
+                        payment.getId(),
+                        payment.getOrderId(),
+                        payment.getAmount(),
+                        payment.getCurrency(),
+                        "Payment declined");
+
+        // Build the event envelope
+        EventEnvelope<PaymentEventPayload> envelope = EventEnvelope.<PaymentEventPayload>builder()
+                .eventType(eventType)
+                .orderId(payment.getOrderId())
+                .correlationId(correlationId)
+                .producer(PRODUCER_NAME)
+                .payload(payload)
+                .build();
+
+        try {
+            String json = objectMapper.writeValueAsString(envelope);
+
+            // CONCEPT: Partition Key
+            // Using orderId as key ensures all events for same order
+            // go to same partition (preserves ordering)
+            kafkaTemplate.send(Topics.PAYMENT_EVENTS, payment.getOrderId(), json)
+                    .whenComplete((result, ex) -> {
+                        if (ex != null) {
+                            log.error("Failed to publish event for order={}: {}",
+                                    payment.getOrderId(), ex.getMessage());
+                        } else {
+                            log.info("Published {} for order={} to partition={}",
+                                    eventType,
+                                    payment.getOrderId(),
+                                    result.getRecordMetadata().partition());
+                        }
+                    });
+
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize event: {}", e.getMessage());
+            throw new RuntimeException("Event serialization failed", e);
+        }
+    }
+}

--- a/services/payment-service/src/main/java/com/delivery/payment/repository/PaymentRepository.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/repository/PaymentRepository.java
@@ -1,0 +1,31 @@
+package com.delivery.payment.repository;
+
+import com.delivery.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * Repository for Payment entity.
+ * 
+ * CONCEPT: Spring Data JPA Repository
+ * - Extend JpaRepository<Entity, IdType> to get CRUD operations for free
+ * - Spring auto-implements this interface at runtime
+ * - Method names become queries: findByOrderId → SELECT * WHERE order_id = ?
+ */
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    /**
+     * Find payment by order ID.
+     * Spring generates: SELECT * FROM payments WHERE order_id = ?
+     */
+    Optional<Payment> findByOrderId(String orderId);
+
+    /**
+     * Check if payment already exists for this idempotency key.
+     * Used to detect duplicates before insert attempt.
+     */
+    boolean existsByIdempotencyKey(String idempotencyKey);
+}

--- a/services/payment-service/src/main/java/com/delivery/payment/service/PaymentProcessor.java
+++ b/services/payment-service/src/main/java/com/delivery/payment/service/PaymentProcessor.java
@@ -1,0 +1,118 @@
+package com.delivery.payment.service;
+
+import com.delivery.payment.dto.PaymentEventPayload;
+import com.delivery.payment.entity.Payment;
+import com.delivery.payment.entity.PaymentStatus;
+import com.delivery.payment.publisher.PaymentEventPublisher;
+import com.delivery.payment.repository.PaymentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+/**
+ * Business logic for payment processing.
+ * 
+ * CONCEPT: Service Layer
+ * - Contains business logic (not in controller or repository)
+ * - Coordinates between multiple components
+ * - Handles transactions with @Transactional
+ */
+@Service
+public class PaymentProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentProcessor.class);
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentEventPublisher paymentEventPublisher;
+
+    public PaymentProcessor(PaymentRepository paymentRepository,
+            PaymentEventPublisher paymentEventPublisher) {
+        this.paymentRepository = paymentRepository;
+        this.paymentEventPublisher = paymentEventPublisher;
+    }
+
+    /**
+     * Process a payment for an order.
+     * 
+     * CONCEPT: Idempotency Handling
+     * 1. Check if payment already exists (by idempotencyKey)
+     * 2. If exists → return existing (duplicate request)
+     * 3. If not exists → create new payment
+     * 4. Handle race condition via unique constraint
+     * 
+     * @param orderId        The order to pay for
+     * @param idempotencyKey Unique key (usually eventId) to prevent duplicates
+     * @param amount         Payment amount
+     * @param currency       Currency code
+     * @param correlationId  For event tracing
+     * @return The payment record
+     */
+    @Transactional
+    public Payment processPayment(String orderId, String idempotencyKey,
+            BigDecimal amount, String currency,
+            String correlationId) {
+
+        log.info("Processing payment: orderId={}, idempotencyKey={}, amount={}",
+                orderId, idempotencyKey, amount);
+
+        // Step 1: Check for existing payment (idempotency)
+        if (paymentRepository.existsByIdempotencyKey(idempotencyKey)) {
+            log.info("Payment already processed for idempotencyKey={}", idempotencyKey);
+            return paymentRepository.findByOrderId(orderId).orElseThrow();
+        }
+
+        // Step 2: Create new payment
+        Payment payment = Payment.create(orderId, idempotencyKey, amount, currency);
+
+        try {
+            // Step 3: Simulate payment processing
+            boolean paymentSuccessful = simulatePaymentGateway(amount);
+
+            if (paymentSuccessful) {
+                payment.authorize();
+                log.info("Payment authorized for orderId={}", orderId);
+            } else {
+                payment.fail();
+                log.warn("Payment failed for orderId={}", orderId);
+            }
+
+            // Step 4: Save to database
+            payment = paymentRepository.save(payment);
+
+            // Step 5: Publish event to Kafka
+            paymentEventPublisher.publishPaymentEvent(payment, correlationId);
+
+            return payment;
+
+        } catch (DataIntegrityViolationException e) {
+            // CONCEPT: Race Condition Handling
+            // If two threads try to insert same idempotencyKey simultaneously,
+            // one succeeds and one gets this exception.
+            // We catch it and return the existing payment.
+            log.warn("Concurrent duplicate detected for idempotencyKey={}", idempotencyKey);
+            return paymentRepository.findByOrderId(orderId).orElseThrow();
+        }
+    }
+
+    /**
+     * Simulate a payment gateway call.
+     * In real system, this would call Stripe, PayPal, etc.
+     * 
+     * For demo: 90% success rate.
+     */
+    private boolean simulatePaymentGateway(BigDecimal amount) {
+        // Simulate some processing time
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // 90% success rate for demo
+        return Math.random() > 0.1;
+    }
+}


### PR DESCRIPTION

- Add PaymentEventListener to consume inventory.reserved events
- Add PaymentProcessor with idempotency handling via unique constraint
- Add PaymentEventPublisher to publish payment.authorized/failed events
- Add Payment entity with JPA persistence to Postgres
- Add PaymentRepository with Spring Data JPA
- Add JacksonConfig for Java 8 time serialization
- Add DTOs for event payloads (InventoryEventPayload, PaymentEventPayload)
- Add learning-notes.md documenting Kafka, Spring, and system concepts